### PR TITLE
GUI updates & readable name in contact database

### DIFF
--- a/src/bitnamescontacts.cpp
+++ b/src/bitnamescontacts.cpp
@@ -8,14 +8,17 @@ BitNamesContacts::BitNamesContacts()
 {
 
 }
-void BitNamesContacts::AddContact(const uint256& id)
+void BitNamesContacts::AddContact(const uint256& id, const std::string& name)
 {
-    vContactID.push_back(id);
+    Contact contact;
+    contact.id = id;
+    contact.name = name;
+    vContact.push_back(contact);
 }
 
-void BitNamesContacts::SetContacts(const std::vector<uint256> vContact)
+void BitNamesContacts::SetContacts(const std::vector<Contact> vContactIn)
 {
-    vContactID = vContact;
+    vContact = vContactIn;
 }
 
 void BitNamesContacts::SetCurrentID(const uint256 id)
@@ -23,9 +26,9 @@ void BitNamesContacts::SetCurrentID(const uint256 id)
     current = id;
 }
 
-std::vector<uint256> BitNamesContacts::GetContacts() const
+std::vector<Contact> BitNamesContacts::GetContacts() const
 {
-    return vContactID;
+    return vContact;
 }
 
 uint256 BitNamesContacts::GetCurrentID() const
@@ -33,3 +36,13 @@ uint256 BitNamesContacts::GetCurrentID() const
     return current;
 }
 
+bool BitNamesContacts::GetName(const uint256& id, std::string& strName)
+{
+    for (const Contact& c : vContact) {
+        if (c.id == id) {
+            strName = c.name;
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/bitnamescontacts.h
+++ b/src/bitnamescontacts.h
@@ -7,23 +7,31 @@
 
 #include <uint256.h>
 
+#include <string>
 #include <vector>
+
+struct Contact
+{
+    uint256 id;
+    std::string name;
+};
 
 class BitNamesContacts
 {
 public:
     BitNamesContacts();
 
-    void AddContact(const uint256& id);
-    void SetContacts(const std::vector<uint256> vContact);
+    void AddContact(const uint256& id, const std::string& name);
+    void SetContacts(const std::vector<Contact> vContact);
     void SetCurrentID(const uint256 id);
+    bool GetName(const uint256& id, std::string& strName);
 
-    std::vector<uint256> GetContacts() const;
+    std::vector<Contact> GetContacts() const;
     uint256 GetCurrentID() const;
 
 private:
-    // My contact's ID's
-    std::vector<uint256> vContactID;
+    // My contacts
+    std::vector<Contact> vContact;
 
     // My current ID
     uint256 current;

--- a/src/qt/addcontactdialog.cpp
+++ b/src/qt/addcontactdialog.cpp
@@ -38,7 +38,7 @@ void AddContactDialog::on_pushButtonAdd_clicked()
         return; // todo messagebox
     }
 
-    bitnamesContacts.AddContact(bitname.name_hash);
+    bitnamesContacts.AddContact(id, str);
 
     QMessageBox::information(this, tr("Contact added!"),
         tr("BitNames contact saved!\n"),

--- a/src/qt/addcontactdialog.cpp
+++ b/src/qt/addcontactdialog.cpp
@@ -35,7 +35,10 @@ void AddContactDialog::on_pushButtonAdd_clicked()
     // Get BitNameDB data
     BitName bitname;
     if (!pbitnametree->GetBitName(id, bitname)) {
-        return; // todo messagebox
+        QMessageBox::critical(this, tr("Failed to lookup BitName!"),
+            tr("The name you have entered could not be resolved!\n"),
+            QMessageBox::Ok);
+        return;
     }
 
     bitnamesContacts.AddContact(id, str);
@@ -43,4 +46,40 @@ void AddContactDialog::on_pushButtonAdd_clicked()
     QMessageBox::information(this, tr("Contact added!"),
         tr("BitNames contact saved!\n"),
         QMessageBox::Ok);
+
+    this->close();
+}
+
+void AddContactDialog::on_lineEditName_textChanged()
+{
+    std::string str = ui->lineEditName->text().toStdString();
+
+    uint256 id;
+    CHash256().Write((unsigned char*)&str[0], str.size()).Finalize((unsigned char*)&id);
+
+    // Get BitNameDB data
+    BitName bitname;
+    if (pbitnametree->GetBitName(id, bitname)) {
+        ui->labelError->setVisible(false);
+
+        QString result = "";
+        result += "Name hash: " + QString::fromStdString(bitname.name_hash.ToString());
+        result += "\nTxID: " + QString::fromStdString(bitname.txid.front().ToString());
+
+        boost::optional<uint256> commitment = bitname.commitment.front();
+        if (commitment)
+            result += "\nCommitment: " + QString::fromStdString((*commitment).ToString());
+
+        boost::optional<in_addr_t> opt_in4 = bitname.in4.front();
+        if (opt_in4) {
+            struct in_addr in4;
+            in4.s_addr = *opt_in4;
+            result += "\nIPv4: " + QString::fromStdString(std::string(inet_ntoa(in4)));
+        }
+
+        ui->textBrowser->insertPlainText(result);
+    } else {
+        ui->labelError->setVisible(true);
+        ui->textBrowser->clear();
+    }
 }

--- a/src/qt/addcontactdialog.h
+++ b/src/qt/addcontactdialog.h
@@ -24,6 +24,7 @@ private:
 
 private Q_SLOTS:
    void on_pushButtonAdd_clicked();
+   void on_lineEditName_textChanged();
 };
 
 #endif // ADDCONTACTDIALOG_H

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -374,6 +374,11 @@ void BitcoinGUI::createActions()
     verifyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_0));
     tabGroup->addAction(verifyAction);
 
+    // Disable tabs until complete
+    activityAction->setEnabled(false);
+    paymailAction->setEnabled(false);
+    verifyAction->setEnabled(false);
+
 #ifdef ENABLE_WALLET
     connect(sidechainAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(sidechainAction, SIGNAL(triggered()), this, SLOT(gotoSidechainPage()));
@@ -673,11 +678,12 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     usedReceivingAddressesAction->setEnabled(enabled);
     sidechainAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
-    activityAction->setEnabled(enabled);
     browseAction->setEnabled(enabled);
     contactsAction->setEnabled(enabled);
-    paymailAction->setEnabled(enabled);
-    verifyAction->setEnabled(enabled);
+    // TODO
+//    activityAction->setEnabled(enabled);
+//    paymailAction->setEnabled(enabled);
+//    verifyAction->setEnabled(enabled);
 }
 
 void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)

--- a/src/qt/browsepage.cpp
+++ b/src/qt/browsepage.cpp
@@ -83,24 +83,27 @@ void BrowsePage::Update()
 
     ui->tableWidgetContacts->setRowCount(0);
 
-    std::vector<uint256> vContact = bitnamesContacts.GetContacts();
+    std::vector<Contact> vContact = bitnamesContacts.GetContacts();
 
     int nRow = 0;
-    for (const uint256& u : vContact) {
+    for (const Contact& c : vContact) {
         ui->tableWidgetContacts->insertRow(nRow);
 
         // Get BitNameDB data
         BitName bitname;
-        if (!pbitnametree->GetBitName(u, bitname)) {
+        if (!pbitnametree->GetBitName(c.id, bitname)) {
             return;
         }
 
-        QString name = QString::fromStdString(bitname.name_hash.ToString());
+        QString name = QString::fromStdString(c.name);
+        QString id = QString::fromStdString(c.id.ToString());
 
         // Add to table
         QTableWidgetItem* nameItem = new QTableWidgetItem(name);
         nameItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
+        QTableWidgetItem* idItem = new QTableWidgetItem(id);
+        idItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         ui->tableWidgetContacts->setItem(nRow /* row */, 0 /* col */, nameItem);
 
         nRow++;

--- a/src/qt/browsepage.cpp
+++ b/src/qt/browsepage.cpp
@@ -69,6 +69,9 @@ void BrowsePage::on_lineEditSearch_returnPressed()
         QMessageBox::critical(this, tr("Failed to lookup BitName!"),
             tr("You must enter something!\n"),
             QMessageBox::Ok);
+
+        ui->textBrowser->clear();
+
         return;
     }
 
@@ -104,6 +107,7 @@ void BrowsePage::Update()
 
         QTableWidgetItem* idItem = new QTableWidgetItem(id);
         idItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+
         ui->tableWidgetContacts->setItem(nRow /* row */, 0 /* col */, nameItem);
 
         nRow++;

--- a/src/qt/contactspage.cpp
+++ b/src/qt/contactspage.cpp
@@ -21,6 +21,8 @@ ContactsPage::ContactsPage(const PlatformStyle *_platformStyle, QWidget *parent)
 {
     ui->setupUi(this);
 
+    ui->tableWidgetContacts->horizontalHeader()->setStretchLastSection(true);
+
     Update();
 }
 
@@ -41,6 +43,8 @@ void ContactsPage::on_pushButtonSwitch_clicked()
 {
     SwitchBitNamesDialog dialog;
     dialog.exec();
+
+    Update();
 }
 
 void ContactsPage::Update()
@@ -75,5 +79,13 @@ void ContactsPage::Update()
         ui->tableWidgetContacts->setItem(nRow /* row */, 1 /* col */, idItem);
 
         nRow++;
+    }
+
+    std::string strName = "";
+    uint256 current = bitnamesContacts.GetCurrentID();
+    if (bitnamesContacts.GetName(current, strName)) {
+        ui->labelCurrent->setText(QString::fromStdString(strName));
+    } else {
+        ui->labelCurrent->setText("Press switch to create your first BitName");
     }
 }

--- a/src/qt/contactspage.cpp
+++ b/src/qt/contactspage.cpp
@@ -49,25 +49,30 @@ void ContactsPage::Update()
 
     ui->tableWidgetContacts->setRowCount(0);
 
-    std::vector<uint256> vContact = bitnamesContacts.GetContacts();
+    std::vector<Contact> vContact = bitnamesContacts.GetContacts();
 
     int nRow = 0;
-    for (const uint256& u : vContact) {
+    for (const Contact& c : vContact) {
         ui->tableWidgetContacts->insertRow(nRow);
 
         // Get BitNameDB data
         BitName bitname;
-        if (!pbitnametree->GetBitName(u, bitname)) {
+        if (!pbitnametree->GetBitName(c.id, bitname)) {
             return;
         }
 
-        QString name = QString::fromStdString(bitname.name_hash.ToString());
+        QString id = QString::fromStdString(c.id.ToString());
+        QString name = QString::fromStdString(c.name);
 
         // Add to table
         QTableWidgetItem* nameItem = new QTableWidgetItem(name);
         nameItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
+        QTableWidgetItem* idItem = new QTableWidgetItem(id);
+        idItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+
         ui->tableWidgetContacts->setItem(nRow /* row */, 0 /* col */, nameItem);
+        ui->tableWidgetContacts->setItem(nRow /* row */, 1 /* col */, idItem);
 
         nRow++;
     }

--- a/src/qt/forms/addcontactdialog.ui
+++ b/src/qt/forms/addcontactdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>859</width>
+    <height>324</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,10 +22,14 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="textBrowser"/>
+    <widget class="QTextBrowser" name="textBrowser">
+     <property name="placeholderText">
+      <string>Enter BitName above</string>
+     </property>
+    </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="labelError">
      <property name="styleSheet">
       <string notr="true">color:red</string>
      </property>

--- a/src/qt/forms/browsepage.ui
+++ b/src/qt/forms/browsepage.ui
@@ -29,13 +29,6 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Enter a BitName or select a contact and the data will be printed below:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QTextBrowser" name="textBrowser">
          <property name="font">
           <font>
@@ -43,7 +36,7 @@
           </font>
          </property>
          <property name="placeholderText">
-          <string>If the entered BitName can be resolved then the data will be displayed here...</string>
+          <string>Enter BitName or select a contact and the data will be printed below if the BitName can be resolved...</string>
          </property>
         </widget>
        </item>
@@ -54,13 +47,6 @@
        <property name="rightMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Contacts:</string>
-         </property>
-        </widget>
-       </item>
        <item>
         <widget class="QTableWidget" name="tableWidgetContacts">
          <property name="sizePolicy">
@@ -86,7 +72,7 @@
          </property>
          <column>
           <property name="text">
-           <string>Name</string>
+           <string>Contacts</string>
           </property>
          </column>
         </widget>

--- a/src/qt/forms/contactspage.ui
+++ b/src/qt/forms/contactspage.ui
@@ -24,9 +24,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelCurrent">
        <property name="text">
-        <string>LayerTwoLabs</string>
+        <string/>
        </property>
       </widget>
      </item>
@@ -34,6 +34,13 @@
       <widget class="QPushButton" name="pushButtonSwitch">
        <property name="text">
         <string>Switch</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonAdd">
+       <property name="text">
+        <string>Add Contact</string>
        </property>
       </widget>
      </item>
@@ -50,17 +57,19 @@
        </property>
       </spacer>
      </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonAdd">
-       <property name="text">
-        <string>Add Contact</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
     <widget class="QTableWidget" name="tableWidgetContacts">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
      <column>
       <property name="text">
        <string>Name</string>

--- a/src/qt/forms/switchbitnamesdialog.ui
+++ b/src/qt/forms/switchbitnamesdialog.ui
@@ -15,45 +15,20 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Current BitName:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>LayerTwoLabs.bitcoin</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>My BitNames:</string>
+      <string>Double click to switch current BitName</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QTableWidget" name="tableWidgetNames">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
      <column>
       <property name="text">
        <string>Name</string>
@@ -77,6 +52,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonClaim">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>Claim ICANN BitName</string>
        </property>
@@ -84,6 +62,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="pushButtonRecover">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>Recover BitName</string>
        </property>

--- a/src/qt/registerbitnamedialog.cpp
+++ b/src/qt/registerbitnamedialog.cpp
@@ -8,6 +8,8 @@
 #include <QMessageBox>
 
 #include <base58.h>
+#include <bitnamescontacts.h>
+#include <hash.h>
 #include <primitives/transaction.h>
 #include <validation.h>
 #include <wallet/wallet.h>
@@ -135,6 +137,11 @@ void RegisterBitNameDialog::on_pushButtonRegister_clicked()
             "Error: " + QString::fromStdString(strFail),
             QMessageBox::Ok);
     } else {
+        uint256 id;
+        CHash256().Write((unsigned char*)&strName[0], strName.size()).Finalize((unsigned char*)&id);
+
+        bitnamesContacts.AddContact(id, strName);
+
         QMessageBox::information(this, tr("Registered BitName!"),
             "TxID:\n" + QString::fromStdString(tx->GetHash().ToString()),
             QMessageBox::Ok);

--- a/src/qt/switchbitnamesdialog.h
+++ b/src/qt/switchbitnamesdialog.h
@@ -7,6 +7,10 @@
 
 #include <QDialog>
 
+QT_BEGIN_NAMESPACE
+class QTableWidgetItem;
+QT_END_NAMESPACE
+
 namespace Ui {
 class SwitchBitNamesDialog;
 }
@@ -28,6 +32,7 @@ private Q_SLOTS:
     void on_pushButtonRegister_clicked();
     void on_pushButtonClaim_clicked();
     void on_pushButtonRecover_clicked();
+    void on_tableWidgetNames_itemDoubleClicked(QTableWidgetItem* item);
 };
 
 #endif // SWITCHBITNAMESDIALOG_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5869,7 +5869,7 @@ void LoadBitNamesContacts()
         return;
     }
 
-    std::vector<uint256> vContact;
+    std::vector<Contact> vContact;
     uint256 current;
     try {
         int nVersionRequired, nVersionThatWrote;
@@ -5882,11 +5882,11 @@ void LoadBitNamesContacts()
         int nContact = 0;
         filein >> nContact;
         for (int i = 0; i < nContact; i++) {
-            uint256 hash;
-            filein >> hash;
-            vContact.push_back(hash);
+            Contact contact;
+            filein >> contact.id;
+            filein >> contact.name;
+            vContact.push_back(contact);
         }
-
         filein >> current;
     }
     catch (const std::exception& e) {
@@ -5900,7 +5900,7 @@ void LoadBitNamesContacts()
 
 void DumpBitNamesContacts()
 {
-    std::vector<uint256> vContact = bitnamesContacts.GetContacts();
+    std::vector<Contact> vContact = bitnamesContacts.GetContacts();
     uint256 current = bitnamesContacts.GetCurrentID();
 
     int nContact = vContact.size();
@@ -5916,11 +5916,11 @@ void DumpBitNamesContacts()
         fileout << CLIENT_VERSION; // version that wrote the file
 
         fileout << nContact;
-        for (const uint256& u : vContact) {
-            fileout << u;
+        for (const Contact& c : vContact) {
+            fileout << c.id;
+            fileout << c.name;
         }
         fileout << current;
-
     }
     catch (const std::exception& e) {
         LogPrintf("%s: Error writing BitName contacts: %s", __func__, e.what());


### PR DESCRIPTION
* Save contact's readable bitname and the readable name of bitnames we register to bitnames.dat
* Update the AddContactsDialog to resolve bitname before adding
* Show correct current bitname on contacts page
* Allow switching the current bitname
* Disable incomplete tabs

I think that strName can also be removed from the CWalletTx class now but I didn't want to mess with anything you're working on. 

https://github.com/Ash-L2L/sidechains/blob/91f62c4292432f8461d03b00ddfd4fd1964344d2/src/wallet/wallet.h#L335-L336 